### PR TITLE
shell-escape bind password when generating LDIFs

### DIFF
--- a/include/class_ldap.inc
+++ b/include/class_ldap.inc
@@ -1068,7 +1068,7 @@ class LDAP
 
     // Prepare parameters to be valid for shell execution
     $dn     = escapeshellarg($dn);
-    $pwd    = $this->bindpw;
+    $pwd    = escapeshellarg($this->bindpw);
     $host   = escapeshellarg($this->hostname);
     $admin  = escapeshellarg($this->binddn);
     $filter = escapeshellarg($filter);


### PR DESCRIPTION
`generateLdif()` will fail if the bindpw contains `$` (e.g. `a$b`) with an "invalid credentials" error.
this is due to the passwd not being properly protected against shell expansion (the string after the `$` is interpreted as variable name, whih cis most likely empty: `a$b` == `a${b}` => `a`).

this patch calls `escapeshellarg` on the password just like for the other parameters.