### PR TITLE
fixing deprecated warnings in php7

### DIFF
--- a/include/class_CopyPasteHandler.inc
+++ b/include/class_CopyPasteHandler.inc
@@ -55,7 +55,7 @@ class CopyPasteHandler
    *
    * \param string $config
    */
-  function CopyPasteHandler(&$config)
+  function __construct(&$config)
   {
     $this->config   = &$config;
     $this->current  = NULL;

--- a/include/class_filter.inc
+++ b/include/class_filter.inc
@@ -51,7 +51,7 @@ class filter
    *
    * \param string $filename
    */
-  function filter($filename)
+  function __construct($filename)
   {
     // Load eventually passed filename
     if (!$this->load($filename)) {

--- a/include/class_ldap.inc
+++ b/include/class_ldap.inc
@@ -68,7 +68,7 @@ class LDAP
    *
    * \param boolean $tls FALSE
    */
-  function LDAP($binddn, $bindpw, $hostname, $follow_referral = FALSE, $tls = FALSE)
+  function __construct($binddn, $bindpw, $hostname, $follow_referral = FALSE, $tls = FALSE)
   {
     global $config;
     $this->follow_referral  = $follow_referral;

--- a/include/class_listing.inc
+++ b/include/class_listing.inc
@@ -70,7 +70,7 @@ class listing {
    *
    * \param string $data either a filename or an array representation of the XML
    */
-  function listing($data)
+  function __construct($data)
   {
     global $config;
     global $class_mapping;

--- a/include/class_log.inc
+++ b/include/class_log.inc
@@ -52,7 +52,7 @@ class log {
    *
    * \sa log()
    */
-  function log($action, $objecttype, $object, $changes_array = array(), $result = "")
+  function __construct($action, $objecttype, $object, $changes_array = array(), $result = "")
   {
     if (!is_array($changes_array)) {
       trigger_error("log(string,string,string,array(),bool). Forth parameter must be an array.");


### PR DESCRIPTION
This fixes the deprecated warnings in php7.
Some classes were using the class name as a constructor, wich will not be called in future releases of php. Also it may break icon display in webfrontend due to icon header starting with deprecated warnings.