### PR TITLE
Fixing wrong FUNCTIONAL filter

### DIFF
--- a/plugins/admin/users/class_userManagement.inc
+++ b/plugins/admin/users/class_userManagement.inc
@@ -96,7 +96,8 @@ class userManagement extends simpleManagement
       $this->filter->elements['SAMBA']['set']   = '';
     }
     /* The FUNCTIONAL filter must not use inexisting classes */
-    $this->filter->elements['FUNCTIONAL']['set']  = '(!(|(objectClass='.implode(')(objectClass=', $classes).')))';
+    $this->filter->elements['FUNCTIONAL']['set'] = '(|(!(objectClass='.implode('))(!(objectClass=', $classes).')))';
+
   }
 
   function renderList ()


### PR DESCRIPTION
Fix for FUNCTIONAL filter not being built correctly, resulting in empty results.
The NOT condition is now set on every class that needs to be excluded from this filter instead of the whole OR group of classes.
Tested with ldapsearch as well.