### PR TITLE
HTTP header authentication (Redmine #5010)

### DIFF
--- a/contrib/openldap/core-fd-conf.schema
+++ b/contrib/openldap/core-fd-conf.schema
@@ -302,9 +302,22 @@ attributetype ( 1.3.6.1.4.1.38414.8.15.5 NAME 'fdSessionLifeTime'
   SINGLE-VALUE)
 
 attributetype ( 1.3.6.1.4.1.38414.8.15.6 NAME 'fdHttpAuthActivated'
-  DESC 'FusionDirectory - HTTP Auth activation'
+  DESC 'FusionDirectory - HTTP Basic Auth activation'
   EQUALITY booleanMatch
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.7
+  SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.4.1.38414.8.15.7 NAME 'fdHttpHeaderAuthActivated'
+  DESC 'FusionDirectory - HTTP Header Auth activation'
+  EQUALITY booleanMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.7
+  SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.4.1.38414.8.15.8 NAME 'fdHttpHeaderAuthHeaderName'
+  DESC 'FusionDirectory - HTTP Header Auth - Header name'
+  EQUALITY caseExactIA5Match
+  SUBSTR caseExactIA5SubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
   SINGLE-VALUE )
 
 # Debugging
@@ -581,7 +594,7 @@ objectclass ( 1.3.6.1.4.1.38414.8.2.1 NAME 'fusionDirectoryConf'
     fdPrimaryGroupFilter $ fdListSummary $
     fdModificationDetectionAttribute $ fdLogging $ fdLdapSizeLimit $
     fdLoginAttribute $ fdForceSSL $ fdWarnSSL $ fdStoreFilterSettings $ fdSessionLifeTime $
-    fdHttpAuthActivated $
+    fdHttpAuthActivated $ fdHttpHeaderAuthActivated $ fdHttpHeaderAuthHeaderName $
     fdDisplayErrors $ fdLdapMaxQueryTime $ fdLdapStats $ fdDebugLevel $
     fdEnableSnapshots $ fdSnapshotBase $
     fdTabHook $ fdShells $ fdDisplayHookOutput $

--- a/plugins/config/class_configInLdap.inc
+++ b/plugins/config/class_configInLdap.inc
@@ -209,9 +209,19 @@ class configInLdap extends simplePlugin
             0 /*min*/, FALSE /*no max*/, 1800
           ),
           new BooleanAttribute (
-            _('HTTP authentication'), _('Use HTTP authentication protocol instead of the login form.'),
+            _('HTTP Basic authentication'), _('Use HTTP Basic authentication protocol instead of the login form.'),
             'fdHttpAuthActivated', FALSE,
             FALSE
+          ),
+          new BooleanAttribute (
+            _('HTTP Header authentication'), _('Use HTTP Header authentication instead of the login form.'),
+            'fdHttpHeaderAuthActivated', FALSE,
+            FALSE
+          ),
+          new StringAttribute (
+            _('Header name'), _('Name of the header containing user identifier.'),
+            'fdHttpHeaderAuthHeaderName', FALSE,
+            'AUTH_USER'
           ),
         )
       ),


### PR DESCRIPTION
Hi,

here is a contribution related to https://forge.fusiondirectory.org/issues/5010

I added two configuration attributes, as suggested in the Redmine issue. The HTTP header authentication works as the other (Basic, CAS): if it fails, no failback is done on the login form. This could be an enhancement.

There will also be some translation work to do, but I think this should be done later with transifex.

Let me know if you need something else.

This work is released under the same license than FusionDirectory itself (GPLv2) and copyright goes to Savoir-faire Linux and myself.