### PR TITLE
Fix the password recovery problem

### DIFF
--- a/html/class_passwordRecovery.inc
+++ b/html/class_passwordRecovery.inc
@@ -554,7 +554,7 @@ class passwordRecovery extends standAlonePage {
     }
 
     $reinit_link = $this->getPageURL();
-    $reinit_link .= "?uniq=".urlencode($activatecode);
+    $reinit_link .= "?uniq=".urlencode($token);
     $reinit_link .= "&uid=".urlencode($this->uid);
     $reinit_link .= "&email_address=".urlencode($this->email_address);
 


### PR DESCRIPTION
The url received in the password recovery email doesn't contain the validation token