### PR TITLE
Remove max password length from recovery page templates

### DIFF
--- a/ihtml/themes/breezy/recovery.tpl
+++ b/ihtml/themes/breezy/recovery.tpl
@@ -52,7 +52,7 @@
       <label for="new_password_repeated">
         <img class="center" src="geticon.php?context=status&amp;icon=dialog-password&amp;size=48" alt="{t}New password repeated{/t}" title="{t}New password repeated{/t}"/>&nbsp;
       </label>
-      <input type="password" name="new_password_repeated" id="new_password_repeated" maxlength="40" value="" title="{t}New password repeated{/t}" />
+      <input type="password" name="new_password_repeated" id="new_password_repeated" value="" title="{t}New password repeated{/t}" />
       <br>
       <div style="width: 190px; display: inline-block; margin-left: 54px;" title="{t}Password strength{/t}">
         <span id="meterEmpty" style="padding:0;margin:0;width:100%;background-color:#DC143C;display:block;height:5px;">

--- a/ihtml/themes/legacy/recovery.tpl
+++ b/ihtml/themes/legacy/recovery.tpl
@@ -53,7 +53,7 @@
       <label for="new_password_repeated">
         <img class="center" src="geticon.php?context=status&amp;icon=dialog-password&amp;size=48" alt="{t}New password repeated{/t}" title="{t}New password repeated{/t}"/>&nbsp;
       </label>
-      <input type="password" name="new_password_repeated" id="new_password_repeated" maxlength="40" value="" title="{t}New password repeated{/t}" />
+      <input type="password" name="new_password_repeated" id="new_password_repeated" value="" title="{t}New password repeated{/t}" />
       <br>
       <div style="width: 190px; display: inline-block; margin-left: 54px;" title="{t}Password strength{/t}">
         <span id="meterEmpty" style="padding:0;margin:0;width:100%;background-color:#DC143C;display:block;height:5px;">


### PR DESCRIPTION
Similarly to https://github.com/fusiondirectory/fusiondirectory/issues/45, there still were `maxlength` constraints in place for the password recovery pages which would result in a mismatch error when passwords were longer than 40 characters.