### PR TITLE
:sparkles: feat(core): Add ability to extend Smarty plugin search path

### DIFF
--- a/contrib/bin/fusiondirectory-setup
+++ b/contrib/bin/fusiondirectory-setup
@@ -602,6 +602,9 @@ if (!defined("CONFIG_FILE")) {
 /* Path for smarty3 libraries */
 define("SMARTY", "$vars{fd_smarty_path}");
 
+/* Directories to add to Smarty plugins search path */
+//define("SMARTY_PLUGINS_EXTRA", "$vars{fd_home}/contrib/smarty/plugins/");
+
 /* Smarty compile dir */
 define ("SPOOL_DIR", "$vars{fd_spool_dir}/"); /* FusionDirectory spool directory */
 

--- a/include/php_setup.inc
+++ b/include/php_setup.inc
@@ -355,6 +355,10 @@ $smarty->caching      = Smarty::CACHING_OFF;
 $smarty->assign('css_files', []);
 $smarty->assign('js_files', []);
 
+if (defined("SMARTY_PLUGINS_EXTRA")) {
+  $smarty->addPluginsDir((array)SMARTY_PLUGINS_EXTRA);
+}
+
 $smarty->registerPlugin('modifier', 'base64_encode', 'base64_encode');
 
 $smarty->php_handling = Smarty::PHP_REMOVE;

--- a/include/variables.inc
+++ b/include/variables.inc
@@ -45,6 +45,11 @@ if (!defined("CONFIG_FILE")) {
 define("SMARTY", "/usr/share/php/smarty3/Smarty.class.php");
 
 /*!
+ * \brief Directories to add to Smarty plugins search path
+ */
+//define("SMARTY_PLUGINS_EXTRA", "/var/www/fusiondirectory/contrib/smarty/plugins/");
+
+/*!
  * \brief Smarty compile dir
  */
 define("SPOOL_DIR", "/var/spool/fusiondirectory/"); /* FusionDirectory spool directory */


### PR DESCRIPTION
The current expectation for installing FusionDirectory seems to be to have to copy the Smarty plugins into the system smarty plugins directory. This is often going to be under `/usr` somewhere, such as `/usr/share/php/smarty3/plugins`.

The FHS rules state that users should not manually create files under `/usr` (except for `/usr/local`) and that it should be managed by packages only. This isn't a problem for the FusionDirectory packages, which can "legally" put files in that location.

However, so that users can manually install FusionDirectory without violating this, the small patch here adds the ability to extend the Smarty3 search path to include other locations, meaning that the FusionDirectory plugins can stay where they are in the FusionDirectory tree, or be installed in a different location, such as `/usr/local/share/...`.

It also makes it easier to run from a git development location, as if the plugins change there is then no need to have to install them.